### PR TITLE
Config for response merging

### DIFF
--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -170,11 +170,13 @@ class Response
             {
                 if($aLastCommand['cmd'] == $aAttributes['cmd'])
                 {
-                    if($aLastCommand['cmd'] == 'js')
+                    if($this->getOption('core.response.merge.js') &&
+                            $aLastCommand['cmd'] == 'js')
                     {
                         $mData = $aLastCommand['data'].'; '.$mData;
                     }
-                    elseif($aLastCommand['cmd'] == 'ap' &&
+                    elseif($this->getOption('core.response.merge.ap') &&
+                            $aLastCommand['cmd'] == 'ap' &&
                             $aLastCommand['id'] == $aAttributes['id'] &&
                             $aLastCommand['prop'] == $aAttributes['prop'])
                     {

--- a/src/Traits/Config.php
+++ b/src/Traits/Config.php
@@ -44,6 +44,8 @@ trait Config
             // 'core.request.uri'               => '',
             'core.request.mode'                 => 'asynchronous',
             'core.request.method'               => 'POST',    // W3C: Method is case sensitive
+            'core.response.merge.ap'            => true,
+            'core.response.merge.js'            => true,
             'core.debug.on'                     => false,
             'core.debug.verbose'                => false,
             'core.process.exit'                 => true,


### PR DESCRIPTION
Added config that allow not merging on js and ap commands. In Xajax weren't merged and merging can change its behavior.

For example, when merging js active, if the first js command fails, it doesn't continue with next commands.

Thank you,

Albert