### PR TITLE
Use Semantic Version Constraints in composer.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .project
 .settings/*
 /jaxon-core.komodoproject
+vendor
+.idea

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "pimple/pimple": "3.0.*",
-        "lemonphp/event": "1.0.*",
-        "matthiasmullie/minify": "1.3.*"
+        "pimple/pimple": "^3.0",
+        "lemonphp/event": "^1.0",
+        "matthiasmullie/minify": "^1.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.7.*"
+        "phpunit/phpunit": "^5.7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Better version constraints to keep it up-to-date and doesn´t prevent other packages from using newer versions when using jaxon-php