### PR TITLE
Fix for issue #117

### DIFF
--- a/src/Request/Handler/ParameterReader.php
+++ b/src/Request/Handler/ParameterReader.php
@@ -197,7 +197,7 @@ class ParameterReader
         switch($cType)
         {
         case 'S':
-            $value = !$sValue ? '' : $sValue;
+            $value = $sValue === false ? '' : $sValue;
             break;
         case 'B':
             $value = $this->convertStringToBool($sValue);


### PR DESCRIPTION
**substr** can return **false** on fail or a valid **string**, so it has to be strictly compared to **false** or return the value itself.