### PR TITLE
Flush output buffer completely before exiting.

### DIFF
--- a/src/App/Ajax/SendTrait.php
+++ b/src/App/Ajax/SendTrait.php
@@ -63,6 +63,10 @@ trait SendTrait
 
         if($this->xConfigManager->getOption('core.process.exit', false))
         {
+            ob_flush();
+            ob_end_flush();
+            session_write_close();
+            fastcgi_finish_request();
             exit();
         }
     }


### PR DESCRIPTION
This addresses issue #139 

This code only executes when the core.process.exit is set to true.

This will completely flush the response immediately so any background processes queued with register_shutdown_function will run in the background and the client will not have to wait for them to finish to get the response.

(Used when sending email in background )